### PR TITLE
blacklist webpackJsonp and webpackJsonpCallback

### DIFF
--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -69,6 +69,8 @@ ObjectGraph.prototype.blacklistedKeys = [ uid.key, uid.key__, '__proto__' ];
 ObjectGraph.prototype.blacklistedObjects = [
   '_', // lodash.
   '__core-js_shared__', // Part of core-js in babel-runtime.
+  'webpackJsonpCallback',
+  'webpackJsonp'.       // Webpack generated scripts.
 ].map(function(key) {
   return this[key];
 }.bind(typeof window === 'undefined' ? global : window)).filter(


### PR DESCRIPTION
webpackJsonp is a part of wabpack generated code, not a part of browser web APIs.