### PR TITLE
Extract inherited properties from prototype chain

### DIFF
--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -143,7 +143,6 @@ ObjectGraph.prototype.maybeSkip = function(o) {
   var typeOf = typeof o;
   if ( this.types[typeOf] ) return this.types[typeOf];
   if ( this.data[uid.getId(o)] ) return uid.getId(o);
-
   return null;
 };
 
@@ -215,7 +214,7 @@ ObjectGraph.prototype.visitInstance = function(o, dataMap) {
 ObjectGraph.prototype.visitProperty = function(o, propertyName, dataMap) {
   var name = this.rewriteName(propertyName);
   try {
-    dataMap[name] = this.visitObject(o[propertyName], propertyName === 'prototype');
+    dataMap[name] = this.visitObject(o[propertyName]);
   } catch (e) {
     // console.warn('Error accessing', o['+UID'], '.', propertyName);
     dataMap[name] = this.types.exception;
@@ -277,9 +276,9 @@ ObjectGraph.prototype.visitObject = function(o, opt) {
 
   var dataMap = this.storeObject(id);
   var metadataMap = this.storeMetadata(id);
+  this.visitPrototype(o, dataMap);
 
-  // Enqueue work: Visit o's prototype and property descriptors.
-  this.q.enqueue(this.visitPrototype.bind(this, o, dataMap));
+  // Enqueue work: Visit o's property descriptors.
   this.q.enqueue(this.visitPropertyDescriptors.bind(this, o,
                                                     metadataMap));
 

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -255,6 +255,8 @@ ObjectGraph.prototype.visitPropertyDescriptors = function(o, metadataMap) {
 // Visit an object, o. Return an id for the object, which may contain type
 // information (e.g., number, boolean, null), or indicate the unique identity
 // of the object itself.
+// opt contains information about this object.
+//     proto: if this object is visit as a __proto__ of other object.
 ObjectGraph.prototype.visitObject = function(o, opt) {
   opt = opt || {};
   let proto = opt.proto || false;

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -184,10 +184,6 @@ ObjectGraph.prototype.rewriteName = function(name) {
 
 // Visit the prototype of o, given its dataMap.
 ObjectGraph.prototype.visitPrototype = function(o, dataMap) {
-  if ( this.protos[uid.getId(o)] !== undefined ) {
-    console.log(uid.getId(o));
-    return;
-  }
   this.storeProto(uid.getId(o), this.visitObject(o.__proto__, {proto: true}));
 };
 
@@ -302,7 +298,7 @@ ObjectGraph.prototype.visitObject = function(o, opt) {
   // and it does not have constructor property.
   // TODO: This strategy isn't sound, whether a object is a prototype or not
   // is not sure until the entire object is visited.
-  if ( proto !== true && !o.hasOwnProperty('constructor') &&
+  if ( proto !== true && ! o.hasOwnProperty('constructor') &&
     typeof o === 'object' ) {
     this.instanceQueue.enqueue(this.visitInstance.bind(this, o, dataMap))
   }

--- a/src/TaskQueue.js
+++ b/src/TaskQueue.js
@@ -54,7 +54,12 @@ TaskQueue.prototype.flush = function() {
   else                     this.onDone();
 };
 
+// Return if the task queue is empty.
+TaskQueue.prototype.empty = function() {
+  return this.q.length === 0;
+}
+
 module.exports = facade(TaskQueue, {
   properties: [ 'maxDequeueSize', 'onTick', 'onDone' ],
-  methods: { enqueue: 1, flush: 1 },
+  methods: { enqueue: 1, flush: 1, empty: 1 },
 });


### PR DESCRIPTION
I created another task queue to store visitInstances task. Instances' inherited properties will be visited. Properties like document.body are visited in this object graph.

- A instance is defined as: an object without constructor property and it is not a prototype of another object.
- Inherited properties are defined as: a property exists as a property in it's prototype chain, and it's value is exception in it's prototype's data.