### PR TITLE
Four visitor pattern changes

### DIFF
--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -165,6 +165,11 @@ ObjectGraph.prototype.maybeSkip = function(o) {
 
 // Return true if and only if o[key] is a blacklisted object.
 ObjectGraph.prototype.isPropertyBlacklisted = function(o, key) {
+  for ( var i = 0; i < this.blacklistedProperties.length; i++ ) {
+    if ( o.constructor && key === this.blacklistedProperties[i][1] &&
+      o.constructor.name === this.blacklistedProperties[i][0] )
+        return true;
+  }
   var value;
   try {
     value = o[key];
@@ -173,11 +178,6 @@ ObjectGraph.prototype.isPropertyBlacklisted = function(o, key) {
   }
   for ( var i = 0; i < this.blacklistedObjects.length; i++ ) {
     if ( value === this.blacklistedObjects[i] ) return true;
-  }
-  for ( var i = 0; i < this.blacklistedProperties.length; i++ ) {
-    if ( o.constructor && key === this.blacklistedProperties[i][1] &&
-      o.constructor.name === this.blacklistedProperties[i][0] )
-        return true;
   }
   return false;
 };

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -210,7 +210,7 @@ ObjectGraph.prototype.getProtoPropertyNames = function(id) {
   var protoId = this.getPrototype(id);
   if ( ! protoId || this.isType(protoId) ) return emptyArray;
   var exceptionProps = this.getObjectKeys(id, (prop, key) =>
-    prop === this.types.exception
+    prop === this.types.exception || prop === this.types.undefined
   );
   return exceptionProps.concat(this.getProtoPropertyNames(protoId));
 };

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -347,8 +347,7 @@ ObjectGraph.prototype.visitObject = function(o, opt) {
   // and it does not have constructor property.
   // TODO: This strategy isn't sound, whether a object is a prototype or not
   // is not sure until the entire object is visited.
-  if ( proto !== true && ! o.hasOwnProperty('constructor') &&
-    typeof o === 'object' ) {
+  if ( proto !== true && typeof o === 'object' ) {
     this.instanceQueue.enqueue(this.visitInstance.bind(this, o, dataMap));
   }
 

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -175,7 +175,7 @@ ObjectGraph.prototype.getNameFromConstructor = function(o) {
   if ( oNameMatch !== null ) {
     var fullName = oNameMatch[ObjectGraph.OBJECT_CTOR_NAME_MATCH_IDX];
     var suffixDiff = fullName.length - ObjectGraph.CTOR_SUFFIX.length;
-    if ( fullName.indexOf(ObjectGraph.CTOR_SUFFIX) === suffixDiff ) {
+    if ( fullName.endsWith(ObjectGraph.CTOR_SUFFIX) ) {
       fullName = fullName.substr(0, suffixDiff);
     }
     return fullName;


### PR DESCRIPTION
1. Bug fix: `isPropertyBlacklisted()` perform checks that do not require property lookup before doing lookup (which may throw);
2. `visitInstance()`: Include properties from prototype chain that were `undefined` (in addition to those that threw, presumably due to getter invoked on non-instance);
3. Consolidate "get function name" logic into method and use it for name matching in `visitInstance()`;
4. Relax conditions for triggering `visitInstance()`.