### PR TITLE
Add QQ and UC as distinct browsers in NameRewriter

### DIFF
--- a/src/NameRewriter.js
+++ b/src/NameRewriter.js
@@ -60,6 +60,14 @@ NameRewriter.prototype.browsers = [
     name: 'IE',
     re: /(Trident).*rv:([0-9_.]+)/,
   },
+  {
+    name: 'QQ',
+    re: /(M?QQBrowser)\/([0-9_.]+)/,
+  },
+  {
+    name: 'UC',
+    re: /(UC?Browser)\/([0-9_.]+)/,
+  },
 ];
 
 NameRewriter.prototype.platforms = [

--- a/src/NameRewriter.js
+++ b/src/NameRewriter.js
@@ -26,11 +26,20 @@ var NameRewriter = function(opts) {
   this.platforms = opts.platforms || this.platforms.slice();
 };
 
-// Many user agents list multiple parts here.
+// Some user agents will match multiple patterns. The first match will be used,
+// so the order is important. (Chromium-based browsers before Chrome, etc.)
 NameRewriter.prototype.browsers = [
   {
     name: 'Edge',
     re: /(Edge)\/([0-9_.]+)/,
+  },
+  {
+    name: 'QQ',
+    re: /(M?QQBrowser)\/([0-9_.]+)/,
+  },
+  {
+    name: 'UC',
+    re: /(UC?Browser)\/([0-9_.]+)/,
   },
   {
     name: 'Yandex',
@@ -59,14 +68,6 @@ NameRewriter.prototype.browsers = [
   {
     name: 'IE',
     re: /(Trident).*rv:([0-9_.]+)/,
-  },
-  {
-    name: 'QQ',
-    re: /(M?QQBrowser)\/([0-9_.]+)/,
-  },
-  {
-    name: 'UC',
-    re: /(UC?Browser)\/([0-9_.]+)/,
   },
 ];
 


### PR DESCRIPTION
Sample UA strings from Android:

QQ: Mozilla/5.0 (Linux; U; Android 8.1.0; en-us; Pixel 2 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36

UC: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; Pixel 2 Build/OPM1.171019.011) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.5.0.1015 U3/0.8.0 Mobile Safari/534.30

Sample UA strings from Windows:

QQ: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.26 Safari/537.36 Core/1.63.4533.400 QQBrowser/10.0.487.400

UC: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 UBrowser/7.0.185.1002 Safari/537.36

The regexes have been tested to match both variants of each.