### PR TITLE
Treat Cốc Cốc and Samsung as distinct browsers (not Chrome)

### DIFF
--- a/src/NameRewriter.js
+++ b/src/NameRewriter.js
@@ -30,6 +30,10 @@ var NameRewriter = function(opts) {
 // so the order is important. (Chromium-based browsers before Chrome, etc.)
 NameRewriter.prototype.browsers = [
   {
+    name: 'CocCoc',
+    re: /(coc_coc_browser)\/([0-9_.]+)/,
+  },
+  {
     name: 'Edge',
     re: /(Edge)\/([0-9_.]+)/,
   },
@@ -48,6 +52,10 @@ NameRewriter.prototype.browsers = [
   {
     name: 'Opera',
     re: /(OPR)\/([0-9_.]+)/,
+  },
+  {
+    name: 'Samsung',
+    re: /(SamsungBrowser/)\/([0-9_.]+)/,
   },
   {
     name: 'Firefox',

--- a/src/NameRewriter.js
+++ b/src/NameRewriter.js
@@ -55,7 +55,7 @@ NameRewriter.prototype.browsers = [
   },
   {
     name: 'Samsung',
-    re: /(SamsungBrowser/)\/([0-9_.]+)/,
+    re: /(SamsungBrowser)\/([0-9_.]+)/,
   },
   {
     name: 'Firefox',


### PR DESCRIPTION
Example UA strings from a Nexus 5X:

Cốc Cốc: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MTC20K) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/68.4.134 Mobile Chrome/62.4.3202.134 Safari/537.36

Samsung Internet: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MTC20K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36