### PR TITLE
Update handling of UA/environment in ObjectGraph instances

### DIFF
--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -55,18 +55,11 @@ ObjectGraph.prototype.init = function(opts) {
   // Try to prevent recursion into internal structures.
   this.blacklistedObjects.push(this);
 
-  // Lock-in user agent by (potentially) copying it into an own property.
-  this.userAgent = this.userAgent;
-
-  // Initialize environment to match user agent, but may be modified and
-  // serialized as being different. (Not all browsers have precise versioning
-  // encoded in UA string).
-  this.environment = this.nameRewriter.userAgentAsPlatformInfo(this.userAgent);
+  // No default userAgent or environment.
+  this.userAgent = null;
+  this.environment = null;
 };
 
-ObjectGraph.prototype.userAgent = typeof navigator !== 'undefined' ?
-  navigator.userAgent :
-  typeof process !== 'undefined' ? 'NodeJS/' + process.version : 'Unknown';
 // Map of primitive types (leaves in object graph).
 // NOTE: It must be impossible for +UIDs of visited objects to take on these
 // values.

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -54,6 +54,14 @@ ObjectGraph.prototype.init = function(opts) {
 
   // Try to prevent recursion into internal structures.
   this.blacklistedObjects.push(this);
+
+  // Lock-in user agent by (potentially) copying it into an own property.
+  this.userAgent = this.userAgent;
+
+  // Initialize environment to match user agent, but may be modified and
+  // serialized as being different. (Not all browsers have precise versioning
+  // encoded in UA string).
+  this.environment = this.nameRewriter.userAgentAsPlatformInfo(this.userAgent);
 };
 
 ObjectGraph.prototype.userAgent = typeof navigator !== 'undefined' ?
@@ -132,11 +140,6 @@ ObjectGraph.prototype.initLazyData = function() {
   stdlib.memo(this, 'allKeys_', this.getAllKeys_.bind(this));
   stdlib.memo(this, 'allKeysMap_', this.getAllKeysMap_.bind(this));
 
-
-  // Initialize environment to match user agent, but may be modified and
-  // serialized as being different. (Not all browsers have precise versioning
-  // encodd in UA string).
-  this.environment = this.nameRewriter.userAgentAsPlatformInfo(this.userAgent);
 
   this.keysCache = {};
 };
@@ -405,9 +408,6 @@ ObjectGraph.prototype.capture = function(o, opts) {
     return this;
   }
   this.busy = true;
-
-  // Lock-in user agent by (potentially) copying it into an own property.
-  this.userAgent = this.userAgent;
 
   this.timestamp = null;
   this.key = opts.key || '';
@@ -728,6 +728,7 @@ ObjectGraph.prototype.lookupMetaData = function(property, opt_id) {
 ObjectGraph.jsonKeys = [
   'blacklistedKeys',
   'data',
+  'environment',
   'functions',
   'key',
   'keys',
@@ -764,7 +765,7 @@ ObjectGraph.fromJSON = function(o) {
 };
 
 module.exports = facade(ObjectGraph, {
-  properties: [ 'userAgent' ],
+  properties: [ 'userAgent', 'environment' ],
   methods: {
     capture: 1,
     clone: 1,

--- a/src/ObjectGraph.es6.js
+++ b/src/ObjectGraph.es6.js
@@ -128,12 +128,15 @@ ObjectGraph.prototype.initLazyData = function() {
               remap['a:b:c=>b:[(a,c)]'].bind(this, this.data));
   stdlib.memo(this, 'invProtos',
               remap['a:b=>b:[a]'].bind(this, this.protos));
-  stdlib.memo(this, 'environment', function() {
-    return this.nameRewriter.userAgentAsPlatformInfo(this.userAgent);
-  }.bind(this));
   stdlib.memo(this, 'allIds_', this.getAllIds_.bind(this));
   stdlib.memo(this, 'allKeys_', this.getAllKeys_.bind(this));
   stdlib.memo(this, 'allKeysMap_', this.getAllKeysMap_.bind(this));
+
+
+  // Initialize environment to match user agent, but may be modified and
+  // serialized as being different. (Not all browsers have precise versioning
+  // encodd in UA string).
+  this.environment = this.nameRewriter.userAgentAsPlatformInfo(this.userAgent);
 
   this.keysCache = {};
 };
@@ -402,6 +405,9 @@ ObjectGraph.prototype.capture = function(o, opts) {
     return this;
   }
   this.busy = true;
+
+  // Lock-in user agent by (potentially) copying it into an own property.
+  this.userAgent = this.userAgent;
 
   this.timestamp = null;
   this.key = opts.key || '';


### PR DESCRIPTION
UA:

- Lock in on capture to ensure that it is an own property

Environment:

- Copy from (default) UA during lazy data initialization
- Can be overridden (since UA string does not always capture it precisely)
- Store as JSON key (because it's not always derived from UA string anymore)